### PR TITLE
Improve map styling and centering

### DIFF
--- a/landing_brello_sharing.html
+++ b/landing_brello_sharing.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@600;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
 </head>
 
 <body>
@@ -57,16 +58,10 @@
         <p><span class="pill">3 · Riconsegna</span> Lascialo in qualsiasi punto quando vuoi.</p>
         <p class="form-note">Niente app obbligatoria. Niente registrazione. Solo ombrelli.</p>
       </div>
-      <div  class = brelloSearcher> 
-          <input name="città" type="text" placeholder="Es. Alatri" required>        
-          <div class="map-container">
-          <iframe
-          src="https://www.google.com/maps/embed?pb=..."
-          width="100%" height="300" style="border:0;"
-          allowfullscreen loading="lazy"
-          referrerpolicy="no-referrer-when-downgrade">
-          </iframe>
-        </div>
+      <div class="g-6 card brello-searcher">
+        <label for="city-search">Città</label>
+        <input id="city-search" name="città" type="text" placeholder="Es. Alatri" required>
+        <div id="map" class="map-container"></div>
       </div>
     
       
@@ -144,6 +139,7 @@
     <div class="toast__inner" id="toast"></div>
   </div>
 
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -128,6 +128,32 @@ document.getElementById('form-utente').addEventListener('submit', e => {
   toast('Fatto! Ti avviseremo quando arriviamo.');
 });
 
+// Mappa dinamica
+const mapEl = document.getElementById('map');
+if (mapEl && window.L) {
+  const map = L.map(mapEl).setView([41.8719, 12.5674], 6);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap'
+  }).addTo(map);
+
+  const cityInput = document.getElementById('city-search');
+  cityInput.addEventListener('change', () => {
+    const q = cityInput.value.trim();
+    if (!q) return;
+    fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(q + ', Italia')}`)
+      .then(r => r.json())
+      .then(res => {
+        if (res.length) {
+          const { lat, lon } = res[0];
+          map.setView([lat, lon], 13);
+        } else {
+          toast('Città non trovata');
+        }
+      });
+  });
+}
+
 // Anno dinamico nel footer
 document.getElementById('year').textContent = new Date().getFullYear();
 

--- a/style.css
+++ b/style.css
@@ -191,6 +191,20 @@ p{margin:0 0 12px}
 #g6ComeFunziona span {
     color: var(--cream);
 }
+
+.brello-searcher{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+
+.map-container{
+  width:100%;
+  height:300px;
+  border-radius:var(--radius);
+  overflow:hidden;
+  box-shadow:var(--shadow);
+}
 /* FORM */
 form{display:grid; gap:12px}
 label{font-weight:800}


### PR DESCRIPTION
## Summary
- align map search input and map container with site styles
- center interactive map on typed city using OpenStreetMap geocoding

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689defb0e230832a96bc1ed3b82bd226