### PR TITLE
Sync "chi siamo" background with card hover

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
   </header>
   <section id="chiSiamo" aria-label="chiSiamo scrollRadius">
     <div class="chiSiamoSx">
-      <div class=" cardPag2 card1Pag2">
+      <div class=" cardPag2 card1Pag2" data-color="var(--teal)">
         <svg viewBox="0 0 64 64" aria-hidden="true">
           <path fill="var(--cream)"
             d="M32 6c-12.7 0-22.9 8.9-25.2 21.1-.3 1.7 1.7 2.8 3.1 1.7C14 24.8 19.4 22 26 22c5.8 0 9.8 2.1 12.9 5.1 1.3 1.2 3.5.2 3.2-1.6C40.5 14.6 36.7 6 32 6zM30 28v21.2c0 2-1.6 3.6-3.6 3.6-2.2 0-3.9-1.9-3.6-4.1.2-1.6 1.6-2.8 3.2-2.9 1-.1 1.8-.9 1.8-1.9V28h2.2z" />
@@ -65,7 +65,7 @@
           for="city-search">Città</label> <input id="city-search" name="città" type="text" placeholder="Es. Alatri"
           required>
       </div>
-      <div class=" cardPag2 card2Pag2">
+      <div class=" cardPag2 card2Pag2" data-color="var(--rosa)">
         <svg viewBox="0 0 64 64" aria-hidden="true">
           <path fill="var(--cream)"
             d="M32 6c-12.7 0-22.9 8.9-25.2 21.1-.3 1.7 1.7 2.8 3.1 1.7C14 24.8 19.4 22 26 22c5.8 0 9.8 2.1 12.9 5.1 1.3 1.2 3.5.2 3.2-1.6C40.5 14.6 36.7 6 32 6zM30 28v21.2c0 2-1.6 3.6-3.6 3.6-2.2 0-3.9-1.9-3.6-4.1.2-1.6 1.6-2.8 3.2-2.9 1-.1 1.8-.9 1.8-1.9V28h2.2z" />
@@ -74,7 +74,7 @@
         <p> Porta con te l’ombrello per tutto il tempo che ti serve.</p>
         <p> Portalo con te, senza vincoli di tempo.</p>
       </div>
-      <div class=" cardPag2  card3Pag2">
+      <div class=" cardPag2  card3Pag2" data-color="var(--yellow)">
         <svg viewBox="0 0 64 64" aria-hidden="true">
           <path fill="var(--cream)"
             d="M32 6c-12.7 0-22.9 8.9-25.2 21.1-.3 1.7 1.7 2.8 3.1 1.7C14 24.8 19.4 22 26 22c5.8 0 9.8 2.1 12.9 5.1 1.3 1.2 3.5.2 3.2-1.6C40.5 14.6 36.7 6 32 6zM30 28v21.2c0 2-1.6 3.6-3.6 3.6-2.2 0-3.9-1.9-3.6-4.1.2-1.6 1.6-2.8 3.2-2.9 1-.1 1.8-.9 1.8-1.9V28h2.2z" />

--- a/script.js
+++ b/script.js
@@ -170,6 +170,20 @@ if (mapEl && window.L) {
   });
 }
 
+// Cambio gradiente sezione "chi siamo" in base alla card attiva
+const chiSiamo = document.getElementById('chiSiamo');
+if (chiSiamo) {
+  chiSiamo.querySelectorAll('.cardPag2').forEach(card => {
+    card.addEventListener('mouseenter', () => {
+      const col = card.dataset.color;
+      if (col) chiSiamo.style.setProperty('--accent-color', col);
+    });
+    card.addEventListener('mouseleave', () => {
+      chiSiamo.style.removeProperty('--accent-color');
+    });
+  });
+}
+
 // Anno dinamico nel footer
 document.getElementById('year').textContent = new Date().getFullYear();
 

--- a/style.css
+++ b/style.css
@@ -45,11 +45,13 @@ footer {
   display: flex;
   flex-direction: column;
 
+  /* colore del primo radial-gradient, variabile per hover delle card */
+  --accent-color: var(--rosa);
 
   background:
     radial-gradient(var(--r) var(--r) at 50% 50%,
-      var(--rosa) 0 95%, transparent 36%),
-    radial-gradient(calc(var(--r) * 0.4) calc(var(--r) * 0.4) at calc(var(--r) * 1.8)  calc(var(--r) * 3.4) ,
+      var(--accent-color) 0 95%, transparent 36%),
+    radial-gradient(calc(var(--r) * 0.4) calc(var(--r) * 0.4) at calc(var(--r) * 1.8)  calc(var(--r) * 3.4),
       var(--green) 0 95%, transparent 36%),
     linear-gradient(132deg,
       var(--viola) 0 5%,


### PR DESCRIPTION
## Summary
- allow "chi siamo" section background to adopt hovered card color
- expose card theme color via `data-color` attributes
- update JS to drive color change through CSS variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58305df28832a8e7d216346c884c8