### PR TITLE
Switch Leaflet map to Mapbox GL with geocoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
     integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <link href='https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css' rel='stylesheet'>
 </head>
 
 <body>
@@ -220,7 +220,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.min.js"
     integrity="sha384-7qAoOXltbVP82dhxHAUje59V5r2YsVfBafyUDxEdApLPmcdhBPg1DKg1ERo0BZlK"
     crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src='https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js'></script>
     <script src="script.js"></script>
     <script src="scriptCarouselChiSiamo.js"></script>
     <script type="module" src="/scriptEditor.js"></script>

--- a/style.css
+++ b/style.css
@@ -383,6 +383,15 @@ p {
 
 }
 
+.marker {
+  width: 40px;
+  height: 40px;
+  background-size: cover;
+  background-position: center;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
 /* FORM */
 
 .form-section {


### PR DESCRIPTION
## Summary
- import Mapbox GL scripts and styles and drop Leaflet
- initialize mapbox map with navigation/geolocation controls, custom markers and optional route drawing
- replace Nominatim lookup with Mapbox geocoding API and add marker styles

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5cef86bfc832a942012c8f7cc083b