### PR TITLE
feat: style map to match site design

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
       <div class="" style="height: 100%;">
 
-        <div id="map" class="map-container">
+        <div id="map" class="map-container" role="region" aria-label="Mappa dei punti brellò" tabindex="0">
 
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -163,14 +163,14 @@ if (mapEl && window.mapboxgl) {
   }));
 
   const brands = [
-    { coordinates: [12.4964, 41.9028], icon: 'https://placehold.co/40x40?text=A', name: 'Brand A' },
-    { coordinates: [9.19, 45.4642], icon: 'https://placehold.co/40x40?text=B', name: 'Brand B' }
+    { coordinates: [12.4964, 41.9028], name: 'Brand A' },
+    { coordinates: [9.19, 45.4642], name: 'Brand B' }
   ];
 
   brands.forEach(b => {
     const el = document.createElement('div');
     el.className = 'marker';
-    el.style.backgroundImage = `url(${b.icon})`;
+    el.textContent = b.name.charAt(0);
     new mapboxgl.Marker(el)
       .setLngLat(b.coordinates)
       .setPopup(new mapboxgl.Popup({ offset: 25 }).setText(b.name))

--- a/style.css
+++ b/style.css
@@ -376,20 +376,68 @@ p {
 }
 
 .map-container {
-  width: 50vw;
+  width: 100%;
   height: 100%;
-  border-radius: 0px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
   z-index: 1;
+}
 
+@media (min-width: 768px) {
+  #mapContainer .map-container {
+    width: 50vw;
+  }
 }
 
 .marker {
   width: 40px;
   height: 40px;
-  background-size: cover;
-  background-position: center;
+  background: var(--yellow);
+  color: var(--ink);
+  border: 2px solid var(--cream);
   border-radius: 50%;
+  box-shadow: var(--shadow);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-family: inherit;
   cursor: pointer;
+}
+
+.mapboxgl-popup-content {
+  background: var(--ink);
+  color: var(--cream);
+  border-radius: var(--radius);
+  font-family: inherit;
+  padding: 8px 12px;
+}
+
+.mapboxgl-popup-close-button {
+  color: var(--cream);
+}
+
+.mapboxgl-popup-tip {
+  border-top-color: var(--ink);
+  border-bottom-color: var(--ink);
+  border-left-color: var(--ink);
+  border-right-color: var(--ink);
+}
+
+.mapboxgl-ctrl-group {
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.mapboxgl-ctrl-group button {
+  background: var(--cream);
+  color: var(--ink);
+}
+
+.mapboxgl-ctrl-group button:hover {
+  background: var(--yellow);
 }
 
 /* FORM */


### PR DESCRIPTION
## Summary
- style map container and controls to match site theme
- ensure map markers and popups follow brand colors
- add accessibility label to map region

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a5e3349558832a8dcae556311f5827